### PR TITLE
Add `mytype` Decorator

### DIFF
--- a/src/numerical/_operations.py
+++ b/src/numerical/_operations.py
@@ -1,3 +1,4 @@
+import functools
 import typing
 
 from ._types import Quantity
@@ -14,4 +15,12 @@ def binary(f: typing.Callable, a, b, *args, **kwargs):
     x = a._data if isinstance(a, Quantity) else a
     y = b._data if isinstance(b, Quantity) else b
     return f(x, y, *args, **kwargs)
+
+
+def mytype(method: typing.Callable):
+    """Convert the result of `method` to an instance of its class."""
+    @functools.wraps(method)
+    def wrapper(self: Quantity, *args, **kwargs):
+        return type(self)(method(self, *args, **kwargs))
+    return wrapper
 

--- a/src/numerical/mixins.py
+++ b/src/numerical/mixins.py
@@ -7,7 +7,11 @@ from . import _operators
 from ._operations import (
     unary,
     binary,
+    mytype,
 )
+
+
+T = typing.TypeVar('T')
 
 
 class Orderable:
@@ -39,15 +43,19 @@ class Comparable(Orderable):
 class Additive:
     """Operator support for additive numerical objects."""
 
+    @mytype
     def __add__(self, other) -> typing.Self:
         return binary(_operators.add, self, other)
 
+    @mytype
     def __radd__(self, other) -> typing.Self:
         return binary(_operators.add, other, self)
 
+    @mytype
     def __sub__(self, other) -> typing.Self:
         return binary(_operators.sub, self, other)
 
+    @mytype
     def __rsub__(self, other) -> typing.Self:
         return binary(_operators.sub, other, self)
 
@@ -55,15 +63,19 @@ class Additive:
 class Multiplicative:
     """Operator support for multiplicative numerical objects."""
 
+    @mytype
     def __mul__(self, other) -> typing.Self:
         return binary(_operators.mul, self, other)
 
+    @mytype
     def __rmul__(self, other) -> typing.Self:
         return binary(_operators.mul, other, self)
 
+    @mytype
     def __truediv__(self, other) -> typing.Self:
         return binary(_operators.truediv, self, other)
 
+    @mytype
     def __rtruediv__(self, other) -> typing.Self:
         return binary(_operators.truediv, other, self)
 
@@ -71,6 +83,7 @@ class Multiplicative:
 class Algebraic(Additive, Multiplicative):
     """Operator support for algebraic numerical objects."""
 
+    @mytype
     def __pow__(self, other, mod: int|None=None) -> typing.Self:
         return binary(_operators.pow, self, other, mod=mod)
 
@@ -78,12 +91,15 @@ class Algebraic(Additive, Multiplicative):
 class Complex(Algebraic):
     """Operator support for complex-valued numerical objects."""
 
+    @mytype
     def __abs__(self) -> typing.Self:
         return unary(_operators.abs, self)
 
+    @mytype
     def __pos__(self) -> typing.Self:
         return unary(_operators.pos, self)
 
+    @mytype
     def __neg__(self) -> typing.Self:
         return unary(_operators.neg, self)
 
@@ -100,11 +116,12 @@ class Value(Complex):
     def __int__(self) -> int:
         return unary(int, self)
 
+    @mytype
     def __round__(self) -> typing.Self:
         return unary(_operators.round, self)
 
 
-class Sequence(Complex):
+class Sequence(Complex, typing.Generic[T]):
     """Operator support for numerical sequences."""
 
     def __contains__(self, x, /) -> bool:
@@ -116,7 +133,7 @@ class Sequence(Complex):
     def __iter__(self):
         return unary(_operators.iter, self)
 
-    def __getitem__(self, i, /) -> typing.Self:
+    def __getitem__(self, i: typing.SupportsIndex, /) -> T:
         return binary(_operators.getitem, self, i)
 
     def __array__(self, *args, **kwargs) -> numpy.typing.NDArray:
@@ -126,18 +143,23 @@ class Sequence(Complex):
 class Real(Comparable, Complex):
     """Operator support for real-valued numerical objects."""
 
+    @mytype
     def __rpow__(self, other, mod: int|None=None) -> typing.Self:
         return binary(_operators.pow, other, self, mod=mod)
 
+    @mytype
     def __floordiv__(self, other) -> typing.Self:
         return binary(_operators.floordiv, self, other)
 
+    @mytype
     def __rfloordiv__(self, other) -> typing.Self:
         return binary(_operators.floordiv, other, self)
 
+    @mytype
     def __mod__(self, other) -> typing.Self:
         return binary(_operators.mod, self, other)
 
+    @mytype
     def __rmod__(self, other) -> typing.Self:
         return binary(_operators.mod, other, self)
 


### PR DESCRIPTION
This PR adds a decorator the will cause the decorated method to return the result as an instance of the enclosing object's type.