### PR TITLE
Update type-annotation interface

### DIFF
--- a/src/numerical/typeface.py
+++ b/src/numerical/typeface.py
@@ -1,32 +1,40 @@
 """
 Support for type annotations.
 
-This module provides a single interface to type annotations. For example,
-suppose `BestType` is available in the `typing` module starting with Python
-version 3.X, and is available in the `typing_extensions` module for earlier
-versions. If the user is running with Python version <3.X, this module will
-import `BestType` from `typing_extensions`. Otherwise, it will provide the
-implementation in `typing`.
+This module provides a single interface to type annotations, including those
+that are not defined by the operative Python version and those that this package
+prefers to use from future versions.
+
+Examples
+--------
+* Suppose `BestType` is available in the `typing` module starting with Python
+  version 3.X and is available in the `typing_extensions` module for earlier
+  versions. If the user is running with Python version <3.X, this module will
+  import `BestType` from `typing_extensions`. Otherwise, it will import
+  `BestType` from `typing`.
+* Support `UpdatedType` is available in the `typing` module for the user's
+  version of Python, but this package wishes to take advantage of updates since
+  that version. This module will automatically import the version from
+  `typing_extensions`.
 """
 
-import importlib
-from typing import *
+import typing
+import typing_extensions
 
 
 __all__ = ()
 
+EXTENDED = []
+
 def __getattr__(name: str) -> type:
     """Get a built-in type annotation."""
+    if name in EXTENDED:
+        return getattr(typing_extensions, name)
     try:
-        module = importlib.__import__(
-            'typing_extensions',
-            globals=globals(),
-            locals=locals(),
-            fromlist=[name],
-        )
-    except AttributeError as err:
-        raise AttributeError(
-            f"Could not find a type annotation for {name!r}"
-        ) from err
-    return getattr(module, name)
+        attr = getattr(typing, name)
+    except AttributeError:
+        attr = getattr(typing_extensions, name)
+    return attr
+
+
 

--- a/src/numerical/typeface.pyi
+++ b/src/numerical/typeface.pyi
@@ -1,0 +1,5 @@
+"""
+Type help for type our custom type-annotation interface.
+"""
+from typing_extensions import *
+from typing import *


### PR DESCRIPTION
This PR refactors the `typeface` module and introduces typeface.pyi to support syntax highlighting for `typeface`.